### PR TITLE
Query function for version

### DIFF
--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -21,7 +21,7 @@ import Options.Applicative
 import Security.Advisories
 import qualified Security.Advisories.Convert.OSV as OSV
 import Security.Advisories.Git
-import Security.Advisories.Queries (listAffectedBy, parseVersionRange)
+import Security.Advisories.Queries (listVersionRangeAffectedBy, parseVersionRange)
 import Security.Advisories.Generate.HTML
 
 import qualified Command.Reserve
@@ -119,7 +119,7 @@ commandQuery =
                   T.hPutStrLn stderr $ "Cannot parse '--version-spec': " <> e
                   exitFailure
                 Right versionRange' -> do
-                  affectedAdvisories <- listAffectedBy (fromMaybe "." advisoriesPath) packageName versionRange'
+                  affectedAdvisories <- listVersionRangeAffectedBy (fromMaybe "." advisoriesPath) packageName versionRange'
                   case affectedAdvisories of
                     [] -> putStrLn "Not affected"
                     _ -> do

--- a/code/hsec-tools/cabal.project
+++ b/code/hsec-tools/cabal.project
@@ -1,5 +1,3 @@
-tested-with: GHC==9.2.5
-
-packages: *.cabal
+packages: hsec-tools.cabal
 
 package hsec-tools

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -88,6 +88,7 @@ executable hsec-tools
     , hsec-tools
     , optparse-applicative  >=0.17    && <0.19
     , text                  >=1.2     && <3
+    , validation-selective  >=0.1     && <1
 
   hs-source-dirs:   app
   default-language: Haskell2010

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -83,6 +83,7 @@ executable hsec-tools
     , aeson                 >=2.0.1.0 && <3
     , base                  >=4.14    && <4.19
     , bytestring            >=0.10    && <0.12
+    , Cabal-syntax          >=3.8.1.0 && <3.11
     , filepath              >=1.4     && <1.5
     , hsec-tools
     , optparse-applicative  >=0.17    && <0.19

--- a/code/hsec-tools/src/Security/Advisories/Queries.hs
+++ b/code/hsec-tools/src/Security/Advisories/Queries.hs
@@ -6,19 +6,15 @@ module Security.Advisories.Queries
   , listVersionRangeAffectedBy
   , isVersionAffectedBy
   , isVersionRangeAffectedBy
-  , parseVersionRange
   )
 where
 
 import Control.Monad (forM_)
-import Data.Bifunctor (first)
 import System.Exit (exitFailure)
 import System.IO (stderr, hPrint)
 
 import Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Distribution.Parsec (eitherParsec)
 import Distribution.Types.Version (Version)
 import Distribution.Types.VersionInterval (asVersionIntervals)
 import Distribution.Types.VersionRange (VersionRange, anyVersion, earlierVersion, intersectVersionRanges, noVersion, orLaterVersion, unionVersionRanges, withinRange)
@@ -79,7 +75,3 @@ listAffectedByHelper checkAffectedBy root queryPackageName queryVersionish =
       exitFailure
     Success advisories ->
       return $ filter (checkAffectedBy queryPackageName queryVersionish) advisories
-
--- | Parse 'VersionRange' as given to the CLI
-parseVersionRange :: Maybe Text -> Either Text VersionRange
-parseVersionRange  = maybe (return anyVersion) (first T.pack . eitherParsec . T.unpack)

--- a/code/hsec-tools/src/Security/Advisories/Queries.hs
+++ b/code/hsec-tools/src/Security/Advisories/Queries.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Security.Advisories.Queries
-  ( listVersionRangeAffectedBy
+  ( listVersionAffectedBy
+  , listVersionRangeAffectedBy
+  , isVersionAffectedBy
   , isVersionRangeAffectedBy
   , parseVersionRange
   )
@@ -17,47 +19,66 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Distribution.Parsec (eitherParsec)
+import Distribution.Types.Version (Version)
 import Distribution.Types.VersionInterval (asVersionIntervals)
-import Distribution.Types.VersionRange (VersionRange, anyVersion, earlierVersion, intersectVersionRanges, noVersion, orLaterVersion, unionVersionRanges)
+import Distribution.Types.VersionRange (VersionRange, anyVersion, earlierVersion, intersectVersionRanges, noVersion, orLaterVersion, unionVersionRanges, withinRange)
 import Validation (Validation(..))
 
 import Security.Advisories.Definition
 import Security.Advisories.Filesystem
 
+-- | Check whether a package and a version is concerned by an advisory
+isVersionAffectedBy :: Text -> Version -> Advisory -> Bool
+isVersionAffectedBy = isAffectedByHelper withinRange
+
 -- | Check whether a package and a version range is concerned by an advisory
 isVersionRangeAffectedBy :: Text -> VersionRange -> Advisory -> Bool
-isVersionRangeAffectedBy queryPackageName queryVersionRange =
+isVersionRangeAffectedBy = isAffectedByHelper $
+  \queryVersionRange affectedVersionRange ->
+    isSomeVersion (affectedVersionRange `intersectVersionRanges` queryVersionRange)
+  where
+    isSomeVersion :: VersionRange -> Bool
+    isSomeVersion range
+      | [] <- asVersionIntervals range = False
+      | otherwise = True
+
+-- | Helper function for 'isVersionAffectedBy' and 'isVersionRangeAffectedBy'
+isAffectedByHelper :: (a -> VersionRange -> Bool) -> Text -> a -> Advisory -> Bool
+isAffectedByHelper checkWithRange queryPackageName queryVersionish =
     any checkAffected . advisoryAffected
     where
-        checkAffected :: Affected -> Bool
-        checkAffected affected =
-          queryPackageName == affectedPackage affected
-            && isSomeVersion (fromAffected affected `intersectVersionRanges` queryVersionRange)
+      checkAffected :: Affected -> Bool
+      checkAffected affected =
+        queryPackageName == affectedPackage affected
+          && checkWithRange queryVersionish (fromAffected affected)
 
-        fromAffected :: Affected -> VersionRange
-        fromAffected = foldr (unionVersionRanges . fromAffectedVersionRange) noVersion . affectedVersions
+      fromAffected :: Affected -> VersionRange
+      fromAffected = foldr (unionVersionRanges . fromAffectedVersionRange) noVersion . affectedVersions
 
-        fromAffectedVersionRange :: AffectedVersionRange -> VersionRange
-        fromAffectedVersionRange avr = intersectVersionRanges
-          (orLaterVersion (affectedVersionRangeIntroduced avr))
-          (maybe anyVersion earlierVersion (affectedVersionRangeFixed avr))
+      fromAffectedVersionRange :: AffectedVersionRange -> VersionRange
+      fromAffectedVersionRange avr = intersectVersionRanges
+        (orLaterVersion (affectedVersionRangeIntroduced avr))
+        (maybe anyVersion earlierVersion (affectedVersionRangeFixed avr))
 
-        isSomeVersion :: VersionRange -> Bool
-        isSomeVersion range
-            | [] <- asVersionIntervals range = False
-            | otherwise = True
+-- | List the advisories matching a package name and a version
+listVersionAffectedBy :: FilePath -> Text -> Version -> IO [Advisory]
+listVersionAffectedBy = listAffectedByHelper isVersionAffectedBy
 
--- | List the advisories matching package/version range
+-- | List the advisories matching a package name and a version range
 listVersionRangeAffectedBy :: FilePath -> Text -> VersionRange -> IO [Advisory]
-listVersionRangeAffectedBy root queryPackageName queryVersionRange =
-    listAdvisories root >>= \case
-      Failure errors -> do
-        T.hPutStrLn stderr "Cannot parse some advisories"
-        forM_ errors $
-          hPrint stderr
-        exitFailure
-      Success advisories ->
-        return $ filter (isVersionRangeAffectedBy queryPackageName queryVersionRange) advisories
+listVersionRangeAffectedBy = listAffectedByHelper isVersionRangeAffectedBy
+
+-- | Helper function for 'listVersionAffectedBy' and 'listVersionRangeAffectedBy'
+listAffectedByHelper :: (Text -> a -> Advisory -> Bool) -> FilePath -> Text -> a -> IO [Advisory]
+listAffectedByHelper checkAffectedBy root queryPackageName queryVersionish =
+  listAdvisories root >>= \case
+    Failure errors -> do
+      T.hPutStrLn stderr "Cannot parse some advisories"
+      forM_ errors $
+        hPrint stderr
+      exitFailure
+    Success advisories ->
+      return $ filter (checkAffectedBy queryPackageName queryVersionish) advisories
 
 -- | Parse 'VersionRange' as given to the CLI
 parseVersionRange :: Maybe Text -> Either Text VersionRange

--- a/code/hsec-tools/test/Spec/QueriesSpec.hs
+++ b/code/hsec-tools/test/Spec/QueriesSpec.hs
@@ -3,16 +3,19 @@
 
 module Spec.QueriesSpec (spec) where
 
+import Data.Bifunctor (first)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Distribution.Types.VersionRange (VersionRange, VersionRangeF(..), projectVersionRange)
+import qualified Data.Text as T
+import Distribution.Parsec (eitherParsec)
+import Distribution.Types.Version (version0, alterVersion)
+import Distribution.Types.VersionRange (VersionRange, VersionRangeF(..), anyVersion, projectVersionRange)
 import Test.Tasty
 import Test.Tasty.HUnit
 
 import Security.Advisories.Definition
 import Security.Advisories.HsecId
 import Security.Advisories.Queries
-import Distribution.Types.Version (version0, alterVersion)
-import Data.Maybe (fromMaybe)
 
 spec :: TestTree
 spec =
@@ -180,3 +183,7 @@ mkAffectedVersions vr =
 
 packageName :: Text
 packageName = "package-name"
+
+-- | Parse 'VersionRange' as given to the CLI
+parseVersionRange :: Maybe Text -> Either Text VersionRange
+parseVersionRange  = maybe (return anyVersion) (first T.pack . eitherParsec . T.unpack)

--- a/code/hsec-tools/test/Spec/QueriesSpec.hs
+++ b/code/hsec-tools/test/Spec/QueriesSpec.hs
@@ -32,7 +32,7 @@ spec =
          in testCase (title actual query) $
               let query' = versionRange query
                   affectedVersion' = versionRange actual
-              in isAffectedBy packageName query' (mkAdvisory affectedVersion')
+              in isVersionRangeAffectedBy packageName query' (mkAdvisory affectedVersion')
                     @?= expected
   ]
 


### PR DESCRIPTION
Hi @blackheaven ! I am currently working on some tooling for security advisories (nothing to show yet) and found myself in the need to query advisories for a specific version. I started building on your PR and ended up changing some more in addition to the 'listVersionAffectedBy' present in this PR. Feel free to merge it into your work or just cherry-pick the parts you like.
